### PR TITLE
Fix overrideSchedule Scheduler method name

### DIFF
--- a/aiosysbus/api/schedule.py
+++ b/aiosysbus/api/schedule.py
@@ -48,7 +48,7 @@ class Schedule:
 
     def set_schedule(self, conf: dict[str, Any] | None) -> dict[str, Any] | None:
         """Get schedule information."""
-        return self._access.post("Scheduler", "overridedSchedule", conf)
+        return self._access.post("Scheduler", "overrideSchedule", conf)
 
     def set_state(self, conf: dict[str, Any] | None) -> dict[str, Any] | None:
         """Get schedule information."""


### PR DESCRIPTION
In `Schedule.set_schedule()` method, the right method to call seem to be `overrideSchedule` instead of `overridedSchedule` (test and validate on my Livebox) as document [here](https://github.com/p-dor/LiveboxMonitor/blob/4ca4ec8bda7b43c97bc21917bc6611487f8ceb75/docs/API%20Documentation/Livebox%207/Scheduler.txt#L13) and also implement [here](https://github.com/p-dor/LiveboxMonitor/blob/4ca4ec8bda7b43c97bc21917bc6611487f8ceb75/src/LmDeviceInfoTab.py#L307C1-L307C13). With the wrong method name, I have the following error :
```
{'status': None, 'errors': [{'error': 196618, 'description': 'Object or parameter not found', 'info': 'overridedSchedule'}]}
```